### PR TITLE
bpfilter gives -Inf loglik for zero dmeasure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: spatPomp
 Type: Package
 Title: Inference for Spatiotemporal Partially Observed Markov Processes
-Version: 1.0.0
-Date: 2024-11-08
+Version: 1.0.1
+Date: 2025-04-23
 Authors@R: c(
   person("Kidus", "Asfaw", email = "kidusasfaw1990@gmail.com", role = c("aut")),
   person("Edward", "Ionides", email = "ionides@umich.edu",role = c("cre","aut")),
@@ -12,7 +12,8 @@ Authors@R: c(
   person("Jesse", "Wheeler", email = "jeswheel@umich.edu", role = c("ctb")),
   person("Jifan", "Li", email = "jifanli@umich.edu", role = c("ctb")),
   person("Ning", "Ning", email = "patning@tamu.edu", role = c("ctb")),
-  person("Haogao", "Gu", email = "hggu@connect.hku.hk", role = c("ctb")))
+  person("Haogao", "Gu", email = "hggu@connect.hku.hk", role = c("ctb")),
+  person("Kunyang", "He", email = "hkunyang@umich.edu", role = c("ctb")))
 URL: https://github.com/spatPomp-org/spatPomp
 Description: Inference on panel data using spatiotemporal partially-observed Markov process (SpatPOMP) models. The 'spatPomp' package extends 'pomp' to include algorithms taking advantage of the spatial structure in order to assist with handling high dimensional processes. See Asfaw et al. (2024) <doi:10.48550/arXiv.2101.01157> for further description of the package.
 SystemRequirements: For Windows users, Rtools (see https://cran.r-project.org/bin/windows/Rtools/).

--- a/tests/bm.Rout.save
+++ b/tests/bm.Rout.save
@@ -1,7 +1,7 @@
 
-R version 4.4.1 (2024-06-14) -- "Race for Your Life"
+R version 4.4.2 (2024-10-31) -- "Pile of Leaves"
 Copyright (C) 2024 The R Foundation for Statistical Computing
-Platform: x86_64-apple-darwin20
+Platform: aarch64-apple-darwin20
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -249,7 +249,7 @@ name  [,1]   [,2]   [,3]   [,4]   [,5]
 > b_bpfilter_inf <- bpfilter(b_model_zero_dmeasure, Np = Np, block_size = 1)
 > paste("bm bpfilter loglik, zero measurement: ",
 +   round(logLik(b_bpfilter_inf),10))
-[1] "bm bpfilter loglik, zero measurement:  NaN"
+[1] "bm bpfilter loglik, zero measurement:  -Inf"
 > 
 > ## test bpfilter error messages
 > try(bpfilter())


### PR DESCRIPTION
Previously, bpfilter returned NaN. The new behavior matches pomp::pfilter